### PR TITLE
[Issue #2] データベース接続設定

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,13 @@
+# データベース接続設定
+# ローカル環境用の例
+DATABASE_URL=mysql+pymysql://root:password@localhost:3306/kunyomi_db
+
+# 接続情報の説明:
+# - mysql+pymysql: MySQL用のドライバー（pymysql）を使用
+# - root: ユーザー名（環境に合わせて変更）
+# - password: パスワード（環境に合わせて変更）
+# - localhost:3306: ホスト名とポート（デフォルトは3306）
+# - kunyomi_db: データベース名（事前に作成しておく）
+
+# Azure Database for MySQLを使用する場合の例:
+# DATABASE_URL=mysql+pymysql://<username>:<password>@<hostname>:3306/<database>?ssl_ca=<ca-cert-path>

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,0 +1,38 @@
+"""データベース接続設定"""
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+import os
+from dotenv import load_dotenv
+
+# .envファイルから環境変数を読み込む
+load_dotenv()
+
+# データベース接続URLを環境変数から取得
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "mysql+pymysql://root:password@localhost:3306/kunyomi_db"
+)
+
+# SQLAlchemyエンジンを作成
+engine = create_engine(
+    DATABASE_URL,
+    pool_pre_ping=True,  # 接続の有効性をチェック
+    echo=False  # SQLクエリをログ出力するか（開発時はTrue推奨）
+)
+
+# セッション生成用のファクトリ
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+# ベースクラス（モデル定義で使用）
+Base = declarative_base()
+
+
+def get_db():
+    """依存性注入用のDBセッション生成関数"""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,6 @@
 from fastapi import FastAPI
+from sqlalchemy import text
+from app.db import engine
 
 app = FastAPI(
     title="くんよみ API",
@@ -17,4 +19,16 @@ def read_root():
 def health_check():
     """ヘルスチェック用エンドポイント"""
     return {"status": "healthy"}
+
+
+@app.get("/health/db")
+def health_check_db():
+    """データベース接続確認用エンドポイント"""
+    try:
+        with engine.connect() as connection:
+            result = connection.execute(text("SELECT 1"))
+            result.fetchone()
+        return {"status": "healthy", "database": "connected"}
+    except Exception as e:
+        return {"status": "unhealthy", "database": "disconnected", "error": str(e)}
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,9 +5,11 @@ uvicorn[standard]==0.24.0
 # 環境変数管理
 python-dotenv==1.0.0
 
-# 注: データベース関連の依存関係はフェーズ0-2で追加予定
-# sqlalchemy==2.0.23
-# pymysql==1.1.0
-# cryptography==41.0.7  # pymysqlに必要
+# データベース関連
+sqlalchemy==2.0.23
+pymysql==1.1.0
+cryptography==41.0.7  # pymysqlに必要
+
+# マイグレーション（フェーズ0-3で使用予定）
 # alembic==1.12.1
 


### PR DESCRIPTION
## 実装内容
- `requirements.txt`にデータベース関連の依存関係を追加（SQLAlchemy, pymysql, cryptography）
- `backend/app/db.py`にデータベース接続設定を追加（SQLAlchemyセッション管理）
- 環境変数で接続情報を管理できるように設定（`.env`ファイル）
- `.env.example`テンプレートファイルを追加
- データベース接続テスト用エンドポイント（`/health/db`）を追加

## 動作確認
- [x] ローカルMySQLに接続できる
- [x] `/health/db`エンドポイントで接続確認ができる
- [x] 環境変数で接続情報を管理できる

## 関連Issue
Closes #2

## 次のステップ
フェーズ0-3（DBモデル定義）に進みます。