### PR TITLE
Add document detail API with keywords and view count increment

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from sqlalchemy import text
 from app.db import engine
-from app.routers import keywords
+from app.routers import keywords, documents
 
 app = FastAPI(
     title="くんよみ API",
@@ -9,6 +9,7 @@ app = FastAPI(
     version="0.1.0"
 )
 app.include_router(keywords.router)
+app.include_router(documents.router)
 
 
 @app.get("/")

--- a/backend/app/routers/documents.py
+++ b/backend/app/routers/documents.py
@@ -1,0 +1,34 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session, joinedload
+
+from app.db import get_db
+from app.models.document import Document
+from app.schemas.document import DocumentDetailResponse
+
+router = APIRouter(prefix="/api/documents", tags=["documents"])
+
+
+@router.get("/{document_id}", response_model=DocumentDetailResponse)
+def get_document_detail(document_id: int, db: Session = Depends(get_db)):
+    """
+    ドキュメント詳細取得:
+    - keywords も含めて返す
+    - view_count を +1
+    - 存在しないIDは 404
+    """
+    doc = (
+        db.query(Document)
+        .options(joinedload(Document.keywords))
+        .filter(Document.id == document_id)
+        .first()
+    )
+
+    if not doc:
+        raise HTTPException(status_code=404, detail="Document not found")
+
+    # 閲覧数インクリメント
+    doc.view_count += 1
+    db.commit()
+    db.refresh(doc)
+
+    return doc

--- a/backend/app/schemas/document.py
+++ b/backend/app/schemas/document.py
@@ -1,0 +1,28 @@
+from pydantic import BaseModel
+from datetime import datetime
+from typing import List, Optional
+
+from app.schemas.keyword import KeywordResponse
+
+
+class DocumentDetailResponse(BaseModel):
+    id: int
+    title: str
+    content: str
+    genre_id: int
+    external_link: Optional[str]
+    status: str
+
+    created_by: int
+    created_at: datetime
+    updated_by: Optional[int]
+    updated_at: datetime
+
+    helpful_count: int
+    view_count: int
+    helpfulness_score: float
+
+    keywords: List[KeywordResponse]
+
+    class Config:
+        from_attributes = True


### PR DESCRIPTION
Implements GET /api/documents/{id}
- Includes keywords in response
- Increments view_count on each access
- Returns 404 {"detail":"Document not found"} when not found

Verified locally:
- curl -i http://127.0.0.1:8000/api/documents/1 -> 200
- view_count increments in DB (1 -> 2 on repeated requests)

Closes #8
