### PR TITLE
KnowledgeNetwork API like Obsidian

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import text
 from dotenv import load_dotenv
 from app.db import engine
-from app.routers import keywords, documents, genre, documents_list, documents_search
+from app.routers import keywords, documents, genre, documents_list, documents_search, network
 
 # 環境変数を読み込む
 load_dotenv()
@@ -41,6 +41,7 @@ app.include_router(keywords.router)
 app.include_router(documents_search.router)
 app.include_router(documents.router)
 app.include_router(documents_list.router)
+app.include_router(network.router)
 
 
 @app.get("/")

--- a/backend/app/routers/network.py
+++ b/backend/app/routers/network.py
@@ -1,0 +1,195 @@
+# backend/app/routers/network.py
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session, selectinload
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy import func
+from typing import List
+
+from app.db import get_db
+from app.models.genre import Genre
+from app.models.document import Document
+from app.schemas.network import NetworkGraphResponse, NetworkNode, NetworkLink
+
+router = APIRouter(
+    prefix="/api/network",
+    tags=["network"]
+)
+
+
+def _build_genre_nodes_and_links(
+    genres: List[Genre],
+    nodes: List[NetworkNode],
+    links: List[NetworkLink],
+    genre_doc_counts: dict,
+    parent_id: str | None = None
+) -> None:
+    """
+    ジャンルノードとリンクを再帰的に構築
+    
+    Args:
+        genres: ジャンルリスト
+        nodes: ノードリスト（参照渡しで追加）
+        links: リンクリスト（参照渡しで追加）
+        genre_doc_counts: ジャンルIDごとのドキュメント数
+        parent_id: 親ノードID
+    """
+    for genre in genres:
+        genre_node_id = f"genre_{genre.id}"
+        
+        # ジャンルノード追加（レベルとドキュメント数を含む）
+        nodes.append(NetworkNode(
+            id=genre_node_id,
+            label=genre.name,
+            type="genre",
+            genre_id=genre.id,
+            level=genre.level,
+            document_count=genre_doc_counts.get(genre.id, 0)
+        ))
+        
+        # 親がいればリンク追加（ジャンル階層）
+        if parent_id:
+            links.append(NetworkLink(
+                source=parent_id,
+                target=genre_node_id,
+                type="genre_hierarchy"
+            ))
+        
+        # 子ジャンルを再帰処理
+        if genre.children:
+            _build_genre_nodes_and_links(
+                genre.children,
+                nodes,
+                links,
+                genre_doc_counts,
+                parent_id=genre_node_id
+            )
+
+
+@router.get("/graph", response_model=NetworkGraphResponse)
+def get_network_graph(
+    genre_id: int | None = None,
+    include_inactive: bool = False,
+    db: Session = Depends(get_db)
+):
+    """
+    ナレッジベースのネットワークグラフを取得
+    
+    【用途】
+    - ネットワーク図でのジャンル・ドキュメント可視化
+    - Obsidian風のグラフビュー
+    
+    【クエリパラメータ】
+    - genre_id: 特定ジャンルのみ取得（指定しない場合は全体）
+    - include_inactive: 無効なジャンル・ドキュメントも含めるか
+    
+    【レスポンス】
+    - nodes: ジャンルノード + ドキュメントノード
+    - links: ジャンル階層リンク + ジャンル-ドキュメントリンク
+    """
+    try:
+        nodes: List[NetworkNode] = []
+        links: List[NetworkLink] = []
+        
+        # ===============================
+        # 0. ジャンルごとのドキュメント数をカウント（階層考慮）
+        # ===============================
+        # 全ジャンルを取得（pathを使って配下のドキュメントをカウントするため）
+        all_genres = db.query(Genre).all()
+        
+        genre_doc_counts = {}
+        for genre in all_genres:
+            # このジャンルのpathまたはその配下のジャンルに紐づくドキュメントをカウント
+            count_query = db.query(func.count(Document.id)).join(Genre).filter(
+                (Genre.path == genre.path) | (Genre.path.like(f"{genre.path}/%"))
+            )
+            
+            if not include_inactive:
+                count_query = count_query.filter(Document.status == "published")
+            
+            genre_doc_counts[genre.id] = count_query.scalar() or 0
+        
+        # ===============================
+        # 1. ジャンルノード・リンク構築
+        # ===============================
+        if genre_id:
+            # 特定ジャンルのみ取得
+            query = db.query(Genre).filter(Genre.id == genre_id)
+        else:
+            # 全ジャンル取得（トップレベルから）
+            query = db.query(Genre).filter(Genre.parent_id == None)
+        
+        # is_activeフィルター
+        if not include_inactive:
+            query = query.filter(Genre.is_active == True)
+        
+        # 3階層まで効率的に取得
+        query = query.options(
+            selectinload(Genre.children)
+            .selectinload(Genre.children)
+        )
+        
+        genres = query.order_by(Genre.display_order).all()
+        
+        # ジャンルノード・リンクを再帰的に構築（ドキュメント数を含む）
+        _build_genre_nodes_and_links(genres, nodes, links, genre_doc_counts)
+        
+        # ===============================
+        # 2. ドキュメントノード・リンク構築
+        # ===============================
+        doc_query = db.query(Document)
+        
+        # 特定ジャンルの場合、そのジャンル配下のドキュメントのみ
+        if genre_id:
+            # パスを使ってサブジャンルも含める
+            genre = db.query(Genre).filter(Genre.id == genre_id).first()
+            if not genre:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"ジャンルID {genre_id} が見つかりません"
+                )
+            # 例: path="1/5/23" → "1/5/23" または "1/5/23/%" にマッチ
+            doc_query = doc_query.join(Genre).filter(
+                (Genre.path == genre.path) | (Genre.path.like(f"{genre.path}/%"))
+            )
+        
+        # is_activeフィルター（ドキュメントのステータス）
+        if not include_inactive:
+            doc_query = doc_query.filter(Document.status == "published")
+        
+        documents = doc_query.all()
+        
+        # ドキュメントノード・リンク追加
+        for doc in documents:
+            doc_node_id = f"doc_{doc.id}"
+            genre_node_id = f"genre_{doc.genre_id}"
+            
+            # ドキュメントノード追加
+            nodes.append(NetworkNode(
+                id=doc_node_id,
+                label=doc.title,
+                type="document",
+                document_id=doc.id,
+                view_count=doc.view_count,
+                helpful_count=doc.helpful_count
+            ))
+            
+            # ジャンル-ドキュメントリンク追加
+            links.append(NetworkLink(
+                source=genre_node_id,
+                target=doc_node_id,
+                type="genre_document"
+            ))
+        
+        return NetworkGraphResponse(
+            nodes=nodes,
+            links=links
+        )
+        
+    except HTTPException:
+        raise
+    except SQLAlchemyError as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"データベースエラー: {str(e)}"
+        )

--- a/backend/app/schemas/network.py
+++ b/backend/app/schemas/network.py
@@ -1,0 +1,36 @@
+# backend/app/schemas/network.py
+
+from pydantic import BaseModel
+from typing import List, Literal
+
+class NetworkNode(BaseModel):
+    """ネットワークグラフのノード"""
+    id: str  # "genre_1" or "doc_123"
+    label: str  # 表示名
+    type: Literal["genre", "document"]  # ノードタイプ
+    genre_id: int | None = None  # ジャンルID（ジャンルノードのみ）
+    document_id: int | None = None  # ドキュメントID（ドキュメントノードのみ）
+    level: int | None = None  # 階層レベル（ジャンルのみ）
+    document_count: int = 0  # 紐づくドキュメント数（ジャンルのみ）
+    view_count: int = 0  # 閲覧数（ドキュメントのみ）
+    helpful_count: int = 0  # 役立った数（ドキュメントのみ）
+    
+    class Config:
+        from_attributes = True
+
+class NetworkLink(BaseModel):
+    """ネットワークグラフのリンク（エッジ）"""
+    source: str  # ソースノードID
+    target: str  # ターゲットノードID
+    type: Literal["genre_hierarchy", "genre_document"]  # リンクタイプ
+    
+    class Config:
+        from_attributes = True
+
+class NetworkGraphResponse(BaseModel):
+    """ネットワークグラフレスポンス"""
+    nodes: List[NetworkNode]
+    links: List[NetworkLink]
+    
+    class Config:
+        from_attributes = True

--- a/frontend/app/network/page.tsx
+++ b/frontend/app/network/page.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { Suspense } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { BookOpen, Network, BarChart3, Bot, History, Settings, Plus, LogIn, ZoomIn, ZoomOut } from 'lucide-react';
+import KnowledgeNetwork from '@/components/KnowledgeNetwork';
+
+export default function NetworkPage() {
+  const pathname = usePathname();
+
+  return (
+    <div className="min-h-screen bg-white text-slate-900">
+      
+      {/* ヘッダー上段：サービスロゴとアクションボタン */}
+      <header className="flex items-center justify-between px-6 py-3 border-b bg-white sticky top-0 z-30">
+        <Link href="/document-list" className="flex items-center gap-2 hover:opacity-80 transition-opacity">
+          <BookOpen className="text-blue-600" size={32} />
+          <h1 className="text-xl font-bold tracking-tight">ナレッジベース</h1>
+        </Link>
+        <div className="flex items-center gap-3">
+          <button className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-slate-700 hover:text-slate-900 transition-colors">
+            <LogIn size={18} /> ログイン
+          </button>
+          <button className="flex items-center gap-2 px-4 py-2 bg-black text-white text-sm font-medium rounded-md hover:bg-slate-800 transition-colors">
+            <Plus size={18} /> 新規作成
+          </button>
+        </div>
+      </header>
+
+      {/* ヘッダー下段：ナビゲーションタブ
+      <nav className="flex items-center gap-1 px-6 py-2 border-b bg-slate-50/50 sticky top-[65px] z-20">
+        <Link
+          href="/document-list"
+          className={`flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+            pathname === '/document-list'
+              ? 'bg-white text-slate-900 shadow-sm'
+              : 'text-slate-600 hover:text-slate-900 hover:bg-white/50'
+          }`}
+        >
+          <BookOpen size={16} />
+          ナレッジ
+        </Link>
+        <Link
+          href="/network"
+          className={`flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+            pathname === '/network'
+              ? 'bg-white text-slate-900 shadow-sm'
+              : 'text-slate-600 hover:text-slate-900 hover:bg-white/50'
+          }`}
+        >
+          <Network size={16} />
+          ネットワーク
+        </Link>
+        <Link
+          href="/analytics"
+          className={`flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+            pathname === '/analytics'
+              ? 'bg-white text-slate-900 shadow-sm'
+              : 'text-slate-600 hover:text-slate-900 hover:bg-white/50'
+          }`}
+        >
+          <BarChart3 size={16} />
+          分析
+        </Link>
+        <Link
+          href="/ai-search"
+          className={`flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+            pathname === '/ai-search'
+              ? 'bg-white text-slate-900 shadow-sm'
+              : 'text-slate-600 hover:text-slate-900 hover:bg-white/50'
+          }`}
+        >
+          <Bot size={16} />
+          AI検索
+        </Link>
+        <Link
+          href="/history"
+          className={`flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+            pathname === '/history'
+              ? 'bg-white text-slate-900 shadow-sm'
+              : 'text-slate-600 hover:text-slate-900 hover:bg-white/50'
+          }`}
+        >
+          <History size={16} />
+          履歴
+        </Link>
+        <Link
+          href="/settings"
+          className={`flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+            pathname === '/settings'
+              ? 'bg-white text-slate-900 shadow-sm'
+              : 'text-slate-600 hover:text-slate-900 hover:bg-white/50'
+          }`}
+        >
+          <Settings size={16} />
+          設定
+        </Link>
+      </nav> */}
+
+      {/* メインコンテンツ */}
+      <main className="flex-1 bg-slate-50/50 p-4 md:p-8">
+        {/* タイトルセクション */}
+        <div className="max-w-7xl mx-auto mb-6">
+          <h2 className="text-2xl font-bold text-slate-900 mb-2">ナレッジネットワーク</h2>
+          <p className="text-sm text-slate-600">
+            ナレッジ間の関連性を視覚化しています。ノードをクリックして詳細を表示できます。
+          </p>
+        </div>
+
+        {/* ネットワークグラフカード */}
+        <div className="max-w-7xl mx-auto">
+          <div className="bg-white rounded-lg border border-slate-200 shadow-sm overflow-hidden" style={{ height: 'calc(100vh - 280px)' }}>
+            <Suspense
+              fallback={
+                <div className="flex items-center justify-center h-full">
+                  <div className="text-slate-400">読み込み中...</div>
+                </div>
+              }
+            >
+              <KnowledgeNetwork />
+            </Suspense>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/components/KnowledgeNetwork.tsx
+++ b/frontend/components/KnowledgeNetwork.tsx
@@ -1,0 +1,286 @@
+'use client';
+
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import dynamic from 'next/dynamic';
+import type { ForceGraphMethods, NodeObject, LinkObject } from 'react-force-graph-2d';
+import { getNetworkGraph } from '@/lib/api/network';
+import type { NetworkGraphData, NetworkNode } from '@/types/network';
+
+// react-force-graph-2dを動的インポート（SSR回避）
+const ForceGraph2D = dynamic(() => import('react-force-graph-2d'), {
+  ssr: false,
+  loading: () => (
+    <div className="flex items-center justify-center h-full">
+      <div className="text-gray-400">グラフを読み込み中...</div>
+    </div>
+  ),
+});
+
+// 配色定義（画像の青・グレー系、レベルによる色分け）
+const COLORS = {
+  bg: '#FFFFFF', // 背景（白）
+  // ジャンルノード（レベルによる色分け：紺 → 青 → 明るい青）
+  genreLevel1: '#1E3A8A', // Lv1: 紺
+  genreLevel2: '#1D4ED8', // Lv2: 濃い青
+  genreLevel3: '#3B82F6', // Lv3: 青
+  genreLevel4: '#60A5FA', // Lv4: 明るい青
+  genreLevel5: '#93C5FD', // Lv5: 最も明るい青
+  documentNode: '#6B7280', // ドキュメントノード（グレー）
+  genreLink: '#1E40AF', // ジャンル階層リンク（濃い青）
+  docLink: '#D1D5DB', // ドキュメントリンク（薄いグレー）
+  text: '#111827', // テキスト（濃いグレー）
+  highlight: '#3B82F6', // ハイライト（青）
+  hoverBg: '#FFFFFF', // ホバー背景（白）
+};
+
+// ジャンルレベルに応じた色を取得
+const getGenreColor = (level?: number): string => {
+  switch (level) {
+    case 1:
+      return COLORS.genreLevel1;
+    case 2:
+      return COLORS.genreLevel2;
+    case 3:
+      return COLORS.genreLevel3;
+    case 4:
+      return COLORS.genreLevel4;
+    case 5:
+      return COLORS.genreLevel5;
+    default:
+      return COLORS.genreLevel3; // デフォルトは青
+  }
+};
+
+interface KnowledgeNetworkProps {
+  genreId?: number;
+  includeInactive?: boolean;
+}
+
+export default function KnowledgeNetwork({
+  genreId,
+  includeInactive = false,
+}: KnowledgeNetworkProps) {
+  const router = useRouter();
+  const fgRef = useRef<ForceGraphMethods>();
+  
+  const [graphData, setGraphData] = useState<NetworkGraphData>({ nodes: [], links: [] });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [highlightNodes, setHighlightNodes] = useState(new Set<string>());
+  const [highlightLinks, setHighlightLinks] = useState(new Set<string>());
+  const [hoverNode, setHoverNode] = useState<NetworkNode | null>(null);
+
+  // データ取得
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        const data = await getNetworkGraph({ genreId, includeInactive });
+        setGraphData(data);
+        setError(null);
+      } catch (err) {
+        setError('ネットワークグラフの読み込みに失敗しました');
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [genreId, includeInactive]);
+
+  // グラフをフィット
+  const handleZoomToFit = useCallback(() => {
+    if (fgRef.current) {
+      fgRef.current.zoomToFit(400, 50);
+    }
+  }, []);
+
+  // ノードクリック処理
+  const handleNodeClick = useCallback(
+    (node: NodeObject) => {
+      const n = node as NetworkNode;
+      if (n.type === 'document' && n.document_id) {
+        // ドキュメント詳細へ遷移
+        router.push(`/documents/${n.document_id}`);
+      } else if (n.type === 'genre' && n.genre_id) {
+        // ジャンルフィルタを適用（例: ジャンル別一覧へ）
+        router.push(`/documents?genre=${n.genre_id}`);
+      }
+    },
+    [router]
+  );
+
+  // ノードホバー処理（関連ノード・リンクをハイライト）
+  const handleNodeHover = useCallback((node: NodeObject | null) => {
+    if (!node) {
+      setHighlightNodes(new Set());
+      setHighlightLinks(new Set());
+      setHoverNode(null);
+      return;
+    }
+
+    const n = node as NetworkNode;
+    setHoverNode(n);
+
+    // 関連ノード・リンクを抽出
+    const nodes = new Set<string>([n.id]);
+    const links = new Set<string>();
+
+    graphData.links.forEach((link) => {
+      if (link.source === n.id || link.target === n.id) {
+        links.add(`${link.source}-${link.target}`);
+        nodes.add(typeof link.source === 'string' ? link.source : (link.source as any).id);
+        nodes.add(typeof link.target === 'string' ? link.target : (link.target as any).id);
+      }
+    });
+
+    setHighlightNodes(nodes);
+    setHighlightLinks(links);
+  }, [graphData.links]);
+
+  // ノード描画カスタマイズ
+  const paintNode = useCallback(
+    (node: NodeObject, ctx: CanvasRenderingContext2D, globalScale: number) => {
+      const n = node as NetworkNode;
+      const isHighlight = highlightNodes.has(n.id);
+      const isHover = hoverNode?.id === n.id;
+
+      // ノード円の半径（タイプによって変える）
+      const radius = n.type === 'genre' ? 6 : 4;
+      
+      // ノード色（ジャンルはレベルに応じて色分け）
+      const nodeColor = n.type === 'genre' 
+        ? getGenreColor(n.level) 
+        : COLORS.documentNode;
+      const finalColor = isHighlight || isHover ? COLORS.highlight : nodeColor;
+
+      // 円描画
+      ctx.beginPath();
+      ctx.arc(node.x!, node.y!, radius, 0, 2 * Math.PI);
+      ctx.fillStyle = finalColor;
+      ctx.fill();
+
+      // ハイライト時は外枠追加
+      if (isHighlight || isHover) {
+        ctx.strokeStyle = COLORS.highlight;
+        ctx.lineWidth = 1.5;
+        ctx.stroke();
+      }
+
+      // ラベル描画条件
+      let shouldShowLabel = false;
+      
+      if (n.type === 'genre') {
+        // ジャンルLv1は常に表示、Lv2以降はズーム時またはハイライト時のみ
+        if (n.level === 1) {
+          shouldShowLabel = true;
+        } else {
+          shouldShowLabel = globalScale >= 1.5 || isHighlight || isHover;
+        }
+      } else {
+        // ドキュメントはズーム時またはハイライト時のみ
+        shouldShowLabel = globalScale >= 1.5 || isHighlight || isHover;
+      }
+      
+      if (shouldShowLabel) {
+        ctx.font = `${12 / globalScale}px Sans-Serif`;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillStyle = COLORS.text;
+        ctx.fillText(n.label, node.x!, node.y! + radius + 8 / globalScale);
+      }
+    },
+    [highlightNodes, hoverNode]
+  );
+
+  // リンク描画カスタマイズ
+  const paintLink = useCallback(
+    (link: LinkObject, ctx: CanvasRenderingContext2D) => {
+      const l = link as any;
+      const isHighlight = highlightLinks.has(`${l.source.id}-${l.target.id}`);
+
+      // リンク色・太さ
+      const linkColor = l.type === 'genre_hierarchy' ? COLORS.genreLink : COLORS.docLink;
+      ctx.strokeStyle = isHighlight ? COLORS.highlight : linkColor;
+      ctx.lineWidth = isHighlight ? 2 : 1;
+      ctx.globalAlpha = isHighlight ? 1 : 0.3; // 非ハイライト時はより薄く
+
+      // 線描画
+      ctx.beginPath();
+      ctx.moveTo(l.source.x, l.source.y);
+      ctx.lineTo(l.target.x, l.target.y);
+      ctx.stroke();
+      ctx.globalAlpha = 1;
+    },
+    [highlightLinks]
+  );
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-full bg-white">
+        <div className="text-slate-600">グラフを読み込み中...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center h-full bg-white">
+        <div className="text-red-600">{error}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative w-full h-full bg-white">
+      {/* コントロールボタン */}
+      <div className="absolute top-4 right-4 z-10 flex gap-2">
+        <button
+          onClick={handleZoomToFit}
+          className="flex items-center gap-2 px-3 py-2 bg-slate-100 text-slate-700 text-sm rounded-md hover:bg-slate-200 transition-colors border border-slate-200"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0zM10 7v3m0 0v3m0-3h3m-3 0H7" />
+          </svg>
+          全体表示
+        </button>
+      </div>
+
+      {/* ホバー情報 */}
+      {hoverNode && (
+        <div className="absolute top-4 left-4 z-10 bg-white p-3 rounded-md shadow-lg border border-slate-200">
+          <div className="text-slate-900 font-medium text-sm">{hoverNode.label}</div>
+          {hoverNode.type === 'genre' ? (
+            <div className="text-slate-600 text-xs mt-1">
+              {hoverNode.document_count || 0}件のナレッジ
+            </div>
+          ) : (
+            <div className="text-slate-600 text-xs mt-2 space-y-1">
+              <div>閲覧: {hoverNode.view_count}回</div>
+              <div>役立った: {hoverNode.helpful_count}回</div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* グラフ本体 */}
+      <ForceGraph2D
+        ref={fgRef}
+        graphData={graphData}
+        backgroundColor={COLORS.bg}
+        nodeId="id"
+        nodeCanvasObject={paintNode}
+        linkCanvasObject={paintLink}
+        onNodeClick={handleNodeClick}
+        onNodeHover={handleNodeHover}
+        cooldownTime={2000}
+        d3AlphaDecay={0.02}
+        d3VelocityDecay={0.3}
+        enableZoomInteraction={true}
+        enablePanInteraction={true}
+      />
+    </div>
+  );
+}

--- a/frontend/lib/api/index.ts
+++ b/frontend/lib/api/index.ts
@@ -1,3 +1,5 @@
+// frontend/lib/api/index.ts
+
 /**
  * APIクライアント関数のエクスポート
  */
@@ -5,4 +7,5 @@ export * from './client';
 export * from './documents';
 export * from './genres';
 export * from './keywords';
+export * from './network';
 

--- a/frontend/lib/api/network.ts
+++ b/frontend/lib/api/network.ts
@@ -1,0 +1,36 @@
+// frontend/lib/api/network.ts
+
+import { get } from './client';
+import type { NetworkGraphData } from '@/types/network';
+
+/**
+ * ネットワークグラフデータを取得
+ * 
+ * 【用途】
+ * - ネットワーク図でのジャンル・ドキュメント可視化
+ * - Obsidian風のグラフビュー
+ * 
+ * @param options オプション
+ * @param options.genreId 特定ジャンルのみ取得（指定しない場合は全体）
+ * @param options.includeInactive 無効なジャンル・ドキュメントも含めるか
+ * @returns ネットワークグラフデータ（ノード + リンク）
+ */
+export async function getNetworkGraph(options?: {
+  genreId?: number;
+  includeInactive?: boolean;
+}): Promise<NetworkGraphData> {
+  const queryParams = new URLSearchParams();
+  
+  if (options?.genreId) {
+    queryParams.append('genre_id', options.genreId.toString());
+  }
+  
+  if (options?.includeInactive) {
+    queryParams.append('include_inactive', 'true');
+  }
+
+  const queryString = queryParams.toString();
+  const endpoint = `/api/network/graph${queryString ? `?${queryString}` : ''}`;
+  
+  return get<NetworkGraphData>(endpoint);
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "next": "16.1.1",
         "react": "19.2.3",
         "react-dom": "19.2.3",
+        "react-force-graph-2d": "^1.29.0",
         "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
@@ -2342,6 +2343,12 @@
         "tailwindcss": "4.1.18"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
+      "integrity": "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2942,6 +2949,15 @@
         "win32"
       ]
     },
+    "node_modules/accessor-fn": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/accessor-fn/-/accessor-fn-1.5.3.tgz",
+      "integrity": "sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -3256,6 +3272,16 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
+    "node_modules/bezier-js": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/bezier-js/-/bezier-js-6.1.4.tgz",
+      "integrity": "sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/Pomax/bezierjs/blob/master/FUNDING.md"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -3394,6 +3420,18 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvas-color-tracker": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/canvas-color-tracker/-/canvas-color-tracker-1.3.2.tgz",
+      "integrity": "sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "tinycolor2": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3493,6 +3531,222 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-binarytree": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d3-binarytree/-/d3-binarytree-1.0.2.tgz",
+      "integrity": "sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==",
+      "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force-3d": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/d3-force-3d/-/d3-force-3d-3.0.6.tgz",
+      "integrity": "sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-binarytree": "1",
+        "d3-dispatch": "1 - 3",
+        "d3-octree": "1",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-octree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-octree/-/d3-octree-1.1.0.tgz",
+      "integrity": "sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==",
+      "license": "MIT"
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -4437,6 +4691,20 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/float-tooltip": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/float-tooltip/-/float-tooltip-1.7.5.tgz",
+      "integrity": "sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-selection": "2 - 3",
+        "kapsule": "^1.16",
+        "preact": "10"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -4451,6 +4719,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/force-graph": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/force-graph/-/force-graph-1.51.0.tgz",
+      "integrity": "sha512-aTnihCmiMA0ItLJLCbrQYS9mzriopW24goFPgUnKAAmAlPogTSmFWqoBPMXzIfPb7bs04Hur5zEI4WYgLW3Sig==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "18 - 25",
+        "accessor-fn": "1",
+        "bezier-js": "3 - 6",
+        "canvas-color-tracker": "^1.3",
+        "d3-array": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-force-3d": "2 - 3",
+        "d3-scale": "1 - 4",
+        "d3-scale-chromatic": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-zoom": "2 - 3",
+        "float-tooltip": "^1.7",
+        "index-array-by": "1",
+        "kapsule": "^1.16",
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/function-bind": {
@@ -4804,6 +5098,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/index-array-by": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/index-array-by/-/index-array-by-1.4.2.tgz",
+      "integrity": "sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -4817,6 +5120,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -5266,6 +5578,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jerrypick": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/jerrypick/-/jerrypick-1.1.2.tgz",
+      "integrity": "sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -5280,7 +5601,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -5357,6 +5677,18 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/kapsule": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/kapsule/-/kapsule-1.16.3.tgz",
+      "integrity": "sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/keyv": {
@@ -5680,6 +6012,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.22",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.22.tgz",
+      "integrity": "sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -5691,7 +6029,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -5926,7 +6263,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6211,6 +6547,16 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/preact": {
+      "version": "10.28.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.2.tgz",
+      "integrity": "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6225,7 +6571,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -6285,12 +6630,43 @@
         "react": "^19.2.3"
       }
     },
+    "node_modules/react-force-graph-2d": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/react-force-graph-2d/-/react-force-graph-2d-1.29.0.tgz",
+      "integrity": "sha512-Xv5IIk+hsZmB3F2ibja/t6j/b0/1T9dtFOQacTUoLpgzRHrO6wPu1GtQ2LfRqI/imgtaapnXUgQaE8g8enPo5w==",
+      "license": "MIT",
+      "dependencies": {
+        "force-graph": "^1.51",
+        "prop-types": "15",
+        "react-kapsule": "^2.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-kapsule": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/react-kapsule/-/react-kapsule-2.5.7.tgz",
+      "integrity": "sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A==",
+      "license": "MIT",
+      "dependencies": {
+        "jerrypick": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
@@ -7003,6 +7379,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "next": "16.1.1",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "react-force-graph-2d": "^1.29.0",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {

--- a/frontend/types/network.ts
+++ b/frontend/types/network.ts
@@ -1,0 +1,24 @@
+// frontend/types/network.ts
+
+export interface NetworkNode {
+  id: string; // "genre_1" or "doc_123"
+  label: string; // 表示名
+  type: "genre" | "document"; // ノードタイプ
+  genre_id?: number; // ジャンルID（ジャンルノードのみ）
+  document_id?: number; // ドキュメントID（ドキュメントノードのみ）
+  level?: number; // 階層レベル（ジャンルのみ）
+  document_count?: number; // 紐づくドキュメント数（ジャンルのみ）
+  view_count?: number; // 閲覧数（ドキュメントのみ）
+  helpful_count?: number; // 役立った数（ドキュメントのみ）
+}
+
+export interface NetworkLink {
+  source: string; // ソースノードID
+  target: string; // ターゲットノードID
+  type: "genre_hierarchy" | "genre_document"; // リンクタイプ
+}
+
+export interface NetworkGraphData {
+  nodes: NetworkNode[];
+  links: NetworkLink[];
+}


### PR DESCRIPTION
close https://github.com/Shun0914/kunyomi/issues/32

## 概要
ジャンル階層とナレッジ間の関連性を可視化するネットワークグラフ機能を実装。Obsidian風のビジュアルで、ジャンル・ナレッジ間の関係を直感的に把握。樹形図Lv1なので、関連ジャンル数による円の大きさは未実装です。

## 変更内容

### Backend
- **新規エンドポイント**: `/api/network/graph`
- **新規ファイル**:
  - `backend/app/schemas/network.py`: ネットワークグラフ用スキーマ
  - `backend/app/routers/network.py`: APIロジック
  - `backend/app/main.py`: network routerを登録

### Frontend
- **新規ページ**: `/network`
- **新規コンポーネント**: `KnowledgeNetwork.tsx`
- **新規ファイル**:
  - `frontend/types/network.ts`: 型定義
  - `frontend/lib/api/network.ts`: APIクライアント
  - `frontend/components/KnowledgeNetwork.tsx`: グラフコンポーネント
  - `frontend/app/network/page.tsx`: ページコンポーネント

### 主要機能
- ✅ ジャンル名：Lv1は常に表示、Lv2以降はズーム時とポイント時のみ表示
- ✅ ジャンルレベル別色分け（Lv1=紺 → Lv5=明るい青）
- ✅ 階層的ドキュメント数表示（上層ジャンルは配下全ての合計）
- ✅ ホバー時にナレッジ数/閲覧数を表示
- ❌ ノードクリックでナレッジ詳細へ遷移（未実装）
- ✅ 全体表示ボタン、ズーム/パン操作対応

## セットアップ
cd frontend
npm install react-force-graph-2d lucide-react
npm run dev
```