### PR TITLE
[Bugfix#49] ジャンルAPIの307 Temporary Redirectエラー（末尾スラッシュの問題）

### DIFF
--- a/frontend/lib/api/genres.ts
+++ b/frontend/lib/api/genres.ts
@@ -21,7 +21,7 @@ export async function getGenres(includeInactive = false): Promise<Genre[]> {
   }
 
   const queryString = queryParams.toString();
-  const endpoint = `/api/genres${queryString ? `?${queryString}` : ''}`;
+  const endpoint = `/api/genres/${queryString ? `?${queryString}` : ''}`;
   
   return get<Genre[]>(endpoint);
 }
@@ -48,7 +48,7 @@ export async function getGenresFlat(options?: {
   }
 
   const queryString = queryParams.toString();
-  const endpoint = `/api/genres/flat${queryString ? `?${queryString}` : ''}`;
+  const endpoint = `/api/genres/flat/${queryString ? `?${queryString}` : ''}`;
   
   return get<Genre[]>(endpoint);
 }


### PR DESCRIPTION
close https://github.com/Shun0914/kunyomi/issues/49

目的

ジャンル一覧の読み込みに失敗し、「ジャンルの読み込みに失敗しました」というエラーメッセージが表示される

再現手順

- /document-listにアクセス
- （修正前）バックエンドのログで307 Temporary Redirect が表示される
- （修正後）バックエンドのログで307 Temporary Redirect が表示されない

修正方法
- オプション1: フロントエンドのエンドポイントを修正（推奨）を採択
- frontend/lib/api/genres.tsの24行目と51行目を末尾にスラッシュ付きに変更