### PR TITLE
Redirect root path to /document-list

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation';
 
-export default function Home() {
+export default function Page() {
   redirect('/document-list');
 }


### PR DESCRIPTION
## 概要
トップページ（/）にアクセスした際に、/document-list へ自動リダイレクトするよう修正しました。

## 背景
本番環境で / にアクセスすると Next.js のデフォルト（または意図しないページ）が表示され、ユーザーが一覧ページに到達しづらかったため。

## 変更点
- frontend/app/page.tsx を /document-list へ redirect する実装に変更

## 動作確認
- / にアクセスすると /document-list に自動遷移すること
- /document-list が従来通り表示されること

Closes #48
