### PR TITLE
[Issue #49] 余分な修正を戻す（/api/genres/flatを末尾スラッシュなしにする）

### DIFF
--- a/frontend/lib/api/genres.ts
+++ b/frontend/lib/api/genres.ts
@@ -48,7 +48,7 @@ export async function getGenresFlat(options?: {
   }
 
   const queryString = queryParams.toString();
-  const endpoint = `/api/genres/flat/${queryString ? `?${queryString}` : ''}`;
+  const endpoint = `/api/genres/flat${queryString ? `?${queryString}` : ''}`;
   
   return get<Genre[]>(endpoint);
 }


### PR DESCRIPTION
close https://github.com/Shun0914/kunyomi/issues/49

目的
- https://github.com/Shun0914/kunyomi/pull/56 の修正にて、余分な修正を元に戻す

- これによりドキュメント作成画面を表示した際に、ジャンルの表示で307エラーが出なくなる。

再現手順

document-createにアクセス
（修正前）バックエンドのログで307 Temporary Redirect が表示される
（修正後）バックエンドのログで307 Temporary Redirect が表示されない

修正方法

-frontend/lib/api/genres.tsの /api/genres/flat/を/api/genres/flatとする