### PR TITLE
ドキュメント評価API（役立ち度）を実装

### DIFF
--- a/backend/app/schemas/document.py
+++ b/backend/app/schemas/document.py
@@ -29,6 +29,10 @@ class DocumentDetailResponse(BaseModel):
         from_attributes = True
 
 
+class DocumentEvaluateRequest(BaseModel):
+    is_helpful: bool
+
+
 class DocumentCreateRequest(BaseModel):
     """ドキュメント作成リクエスト"""
     # Fieldには制約を一切つけない（すべてカスタムバリデーターで処理）


### PR DESCRIPTION
## 概要
ドキュメントの「役に立った／立たなかった」を記録する評価APIを実装しました。

## 変更内容
- `POST /api/documents/{document_id}/evaluate` を追加
  - リクエストボディ：`{ "is_helpful": true / false }`
  - 1ユーザーにつき1ドキュメント1回までの評価制限（重複時は 409）
  - `is_helpful=true` の場合、`documents.helpful_count` を加算
  - `documents.helpfulness_score` を  
    `round(helpful_count / max(view_count, 1), 2)` で即時更新
- `POST /api/documents/{document_id}/view` を更新
  - `view_count` をインクリメント
  - 上記と同じロジックで `helpfulness_score` を再計算
- `DocumentEvaluateRequest` スキーマを追加

## 動作確認
- `alembic upgrade head` を実行し、評価用テーブルを作成
- `POST /api/documents/{id}/evaluate`（true / false）で評価登録できることを確認
- 同一ドキュメントへの再評価は 409（Already evaluated）になることを確認
- `POST /api/documents/{id}/view` 実行で `view_count` と `helpfulness_score` が更新されることを確認

Closes #29 
