### PR TITLE
issues#53のbuildエラーに対応

### DIFF
--- a/frontend/components/KnowledgeNetwork.tsx
+++ b/frontend/components/KnowledgeNetwork.tsx
@@ -56,7 +56,7 @@ export default function KnowledgeNetwork({
   onGenreSelect,
 }: KnowledgeNetworkProps) {
   const router = useRouter();
-  const fgRef = useRef<ForceGraphMethods>();
+  const fgRef = useRef<ForceGraphMethods | undefined>(undefined);
   const containerRef = useRef<HTMLDivElement>(null);
   
   const [graphData, setGraphData] = useState<NetworkGraphData>({ nodes: [], links: [] });


### PR DESCRIPTION
修正ファイル
- kunyomi\frontend\components\KnowledgeNetwork.tsx

buildエラーの原因
- 今回のエラーメッセージを読み解くと、以下の不一致が起きています。
- あなたのコード (ref={fgRef}): RefObject<... | null> （nullが含まれる読み取り専用Ref）
- ライブラリの期待: MutableRefObject<... | undefined> （nullはダメ、undefinedならOKな書き込み可能Ref）
- Reactにおいて useRef(null) は DOM 要素を直接参照する際（<div ref={ref}> など）の標準的な書き方ですが、react-force-graph のような外部コンポーネントのメソッドを呼ぶための Ref の場合、ライブラリ側の実装によって undefined が好まれることがあります。