### PR TITLE
[Phase 3-3] 評価UIの実装（フロントエンド） #30

### DIFF
--- a/frontend/components/KnowledgeDetail.tsx
+++ b/frontend/components/KnowledgeDetail.tsx
@@ -14,14 +14,43 @@ type DocumentDetail = {
   title?: string;
   content?: string;
   view_count?: number;
+  helpful_count?: number;
+  helpfulness_score?: number;
 };
+
+type EvalStatus = 'none' | 'helpful' | 'not_helpful';
+
+function toErrorMessage(e: unknown): string {
+  if (typeof e === 'string') return e;
+  if (e && typeof e === 'object') {
+    const anyE = e as any;
+    if (anyE?.message) return String(anyE.message);
+    if (anyE?.detail) return String(anyE.detail);
+    try {
+      return JSON.stringify(e);
+    } catch {
+      return String(e);
+    }
+  }
+  return String(e);
+}
+
+function pickNumber(v: unknown, fallback = 0): number {
+  return typeof v === 'number' && Number.isFinite(v) ? v : fallback;
+}
 
 export default function KnowledgeDetail({ id }: Props) {
   const [doc, setDoc] = useState<DocumentDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // StrictModeでも「idごとに1回だけPOST」するためのガード
+  const [evalStatus, setEvalStatus] = useState<EvalStatus>('none');
+  const [helpfulCount, setHelpfulCount] = useState<number>(0);
+  const [helpfulnessScore, setHelpfulnessScore] = useState<number>(0);
+  const [isSubmittingEval, setIsSubmittingEval] = useState(false);
+  const [evalError, setEvalError] = useState<string | null>(null);
+
+  // StrictModeでも「idごとに1回だけPOST」するためのガード（view更新用）
   const postedRef = useRef<Set<string>>(new Set());
 
   // 1) 詳細取得
@@ -31,31 +60,22 @@ export default function KnowledgeDetail({ id }: Props) {
     (async () => {
       setLoading(true);
       setError(null);
+      setEvalError(null);
       setDoc(null);
 
       try {
         const data = (await getDocument(Number(id))) as DocumentDetail;
-        if (!cancelled) setDoc(data);
-      } catch (e: any) {
-  if (cancelled) return;
 
-  // Error / 文字列 / オブジェクト（APIエラーJSON）を全部ちゃんと表示する
-  const msg =
-    typeof e === 'string'
-      ? e
-      : e?.message
-      ? String(e.message)
-      : e?.detail
-      ? String(e.detail)
-      : (() => {
-          try {
-            return JSON.stringify(e);
-          } catch {
-            return String(e);
-          }
-        })();
-
-  setError(msg);
+        if (!cancelled) {
+          setDoc(data);
+          setHelpfulCount(data.helpful_count ?? 0);
+          setHelpfulnessScore(data.helpfulness_score ?? 0);
+          // ここでは「評価済みかどうか」は分からないので evalStatus は触らない
+          // （評価済み判定APIが無い前提）
+        }
+      } catch (e: unknown) {
+        if (cancelled) return;
+        setError(toErrorMessage(e));
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -78,6 +98,59 @@ export default function KnowledgeDetail({ id }: Props) {
     });
   }, [id, doc]);
 
+  const handleEvaluate = async (isHelpful: boolean) => {
+    if (!doc) return;
+    if (evalStatus !== 'none') return;
+
+    try {
+      setIsSubmittingEval(true);
+      setEvalError(null);
+
+      const res = await fetch(`http://127.0.0.1:8000/api/documents/${doc.id}/evaluate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ is_helpful: isHelpful }),
+      });
+
+      if (!res.ok) {
+        // 409 = すでに評価済み（仕様どおり）なので「エラー表示しない」
+        if (res.status === 409) {
+          setEvalError(null);
+          // 押した方に合わせて UI の状態だけ整える（どちらでもOKだが、ここは厳密に）
+          setEvalStatus(isHelpful ? 'helpful' : 'not_helpful');
+          return;
+        }
+
+        const text = await res.text().catch(() => '');
+        throw new Error(`評価送信に失敗しました (${res.status}) ${text}`);
+      }
+
+      const updated = (await res.json()) as Partial<DocumentDetail>;
+
+      // 画面表示を確実に更新（updatedに値が入らないケースでも壊れない）
+      const newHelpfulCount =
+        typeof updated.helpful_count === 'number'
+          ? updated.helpful_count
+          : (doc.helpful_count ?? helpfulCount);
+
+      const newHelpfulnessScore =
+        typeof updated.helpfulness_score === 'number'
+          ? updated.helpfulness_score
+          : (doc.helpfulness_score ?? helpfulnessScore);
+
+      setHelpfulCount(pickNumber(newHelpfulCount, 0));
+      setHelpfulnessScore(pickNumber(newHelpfulnessScore, 0));
+      setEvalStatus(isHelpful ? 'helpful' : 'not_helpful');
+
+      // doc自体も更新（表示に一貫性を出す）
+      setDoc((prev) => (prev ? { ...prev, ...updated } : prev));
+    } catch (e: unknown) {
+      setEvalError(toErrorMessage(e) || '評価送信に失敗しました');
+    } finally {
+      setIsSubmittingEval(false);
+    }
+  };
+
   if (loading) return <div>読み込み中...</div>;
   if (error) return <div>読み込みに失敗しました: {error}</div>;
   if (!doc) return <div>ドキュメントが見つかりませんでした</div>;
@@ -85,12 +158,45 @@ export default function KnowledgeDetail({ id }: Props) {
   return (
     <div>
       <h1>{doc.title ?? `Document ${doc.id}`}</h1>
+
       {typeof doc.view_count === 'number' && <div>閲覧数: {doc.view_count}</div>}
+
+      <div className="mt-3 flex items-center gap-2">
+        <button
+          className={`px-3 py-1 rounded border text-sm ${
+            evalStatus === 'helpful' ? 'bg-black text-white' : ''
+          }`}
+          onClick={() => handleEvaluate(true)}
+          disabled={isSubmittingEval || evalStatus !== 'none'}
+        >
+          👍 役に立った
+        </button>
+
+        <button
+          className={`px-3 py-1 rounded border text-sm ${
+            evalStatus === 'not_helpful' ? 'bg-black text-white' : ''
+          }`}
+          onClick={() => handleEvaluate(false)}
+          disabled={isSubmittingEval || evalStatus !== 'none'}
+        >
+          👎 そうでもない
+        </button>
+
+        {isSubmittingEval && <span className="text-sm text-gray-500">送信中…</span>}
+        {evalStatus !== 'none' && <span className="text-sm text-gray-500">評価済み</span>}
+      </div>
+
+      <div className="mt-2 text-sm text-gray-600">
+        評価件数: {helpfulCount} ／ 役立ち度: {helpfulnessScore.toFixed(2)}
+      </div>
+
+      {evalError && <div className="mt-2 text-sm text-red-600">{evalError}</div>}
+
       <div className="prose dark:prose-invert max-w-none border-t pt-4">
-        <ReactMarkdown 
+        <ReactMarkdown
           remarkPlugins={[remarkGfm]}
           components={{
-            code({ node, inline, className, children, ...props }: any) {
+            code({ inline, className, children, ...props }: any) {
               const match = /language-(\w+)/.exec(className || '');
               return !inline && match ? (
                 <SyntaxHighlighter
@@ -106,7 +212,7 @@ export default function KnowledgeDetail({ id }: Props) {
                   {children}
                 </code>
               );
-            }
+            },
           }}
         >
           {doc.content ?? ''}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,10 +20,10 @@
     "next": "16.1.1",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "react-force-graph-2d": "^1.29.0",
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^16.1.0",
     "remark-gfm": "^4.0.1",
-    "react-force-graph-2d": "^1.29.0",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## What
- ドキュメント詳細画面に評価UI（👍 / 👎）を追加
- 評価送信（POST /api/documents/{id}/evaluate）を実装
- 評価後に「評価済み」表示・ボタン無効化
- 409 Already evaluated はエラー表示せず正常扱い

## How to test
1. フロント: `cd frontend && npm run dev`
2. 詳細画面を開く: http://localhost:3000/documents/5 （任意のID）
3. 👍/👎 を押して、評価件数・役立ち度が更新されること
4. 2回目以降はエラー表示なしで「評価済み」になること

## Files
- frontend/components/KnowledgeDetail.tsx
- frontend/package.json

Closes #30
