### PR TITLE
YAMLファイルの修正：PR#105・107のdeploy失敗の対応

### DIFF
--- a/.github/workflows/main_tech0-gen-11-step3-2-py-54.yml
+++ b/.github/workflows/main_tech0-gen-11-step3-2-py-54.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: python-app
-          path: |
+          path: backend/
             .
             !antenv/
 


### PR DESCRIPTION
1. ログから判明した直接的な原因
2026-01-25T14:08:05.1877686Z /opt/startup/startup.sh: 23: cd: can't cd to backend

何が起きているか：Azure App Service（Linux）が起動しようとしています。

設定されているスタートアップコマンド cd backend && python -m uvicorn ... を実行しようとしました。

しかし、/home/site/wwwroot（アプリのルート）の中に backend というディレクトリが見つからないため、エラーで終了しています。

起動に失敗したため、Azureが自動的に再起動を繰り返し、ログに何度も「APP SERVICE ON LINUX」のアスキーアートが表示されています。